### PR TITLE
Fix så att chrome inte godkänner plats

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,10 +10,16 @@ chrome_options.add_experimental_option("excludeSwitches", ["enable-logging"])
 import time
 import config
 from playsound import playsound
+from selenium.webdriver.chrome.options import Options
+
+opt = Options()
+opt.add_experimental_option("prefs", { 
+    "profile.default_content_setting_values.geolocation": 2, 
+  })
 
 class SeleniumDriver():
     def __init__(self):
-        self.driver = webdriver.Chrome('chromedriver', options=chrome_options)
+        self.driver = webdriver.Chrome('chromedriver', options = opt)
         self.driver.get('https://fp.trafikverket.se/boka/#/licence')
         self.driver.implicitly_wait(0.1)
         self.continue_running = True


### PR DESCRIPTION
*Blev fel kod när jag gjorde min första pull request, den här ska vara rätt*

Lite ovan vid github men hoppas att jag gör rätt. När jag använde scriptet kom Göteborg-Hisingen fram varje gång sidan laddades om. Detta innebar att scriptet trodde att Göteborg-Hisingen var en del av mina platser och valde tider därifrån, trots att jag inte alls vill göra prov i Göteborg. Det visar sig att chromedriver automatiskt ger hemsidor tillåtelse att se platsinfo. Det gjorde så att trafikverket trodde att jag var från Göteborg p.g.a. min ip-adress och förvalde Göteborg-Hisingen som min plats innan scriptet hann byta. Denna version stänger av chromes platsinfo när scriptet startas och gör så att scriptet går att använda om man vill boka tid på en plats som inte är där ip-adressen är från.